### PR TITLE
:construction_worker: Use ci/4.x.y version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ on:
   workflow_dispatch:
   pull_request:
   release:
-    types: [published]
+    types:
+      - published
+      - deleted
   push:
     branches:
       - main
@@ -27,22 +29,22 @@ on:
 
 jobs:
   ci:
-    uses: libhal/ci/.github/workflows/library.yml@4.1.0
+    uses: libhal/ci/.github/workflows/library.yml@4.x.y
     with:
       coverage: true
     secrets: inherit
   deploy:
-    uses: libhal/ci/.github/workflows/deploy.yml@4.1.0
+    uses: libhal/ci/.github/workflows/deploy.yml@4.x.y
     secrets: inherit
   build_lpc4074:
-    uses: libhal/ci/.github/workflows/demo_builder.yml@4.1.0
+    uses: libhal/ci/.github/workflows/demo_builder.yml@4.x.y
     with:
       profile: lpc4074
       processor_profile: https://github.com/libhal/libhal-armcortex.git
       platform_profile: https://github.com/libhal/libhal-lpc40.git
     secrets: inherit
   build_lpc4078:
-    uses: libhal/ci/.github/workflows/demo_builder.yml@4.1.0
+    uses: libhal/ci/.github/workflows/demo_builder.yml@4.x.y
     with:
       profile: lpc4078
       processor_profile: https://github.com/libhal/libhal-armcortex.git


### PR DESCRIPTION
The 4.x.y branch scheme means that this repo will get the latest changes to the ci that does not include breaking changes.